### PR TITLE
fix: add server-side date filtering and FundHistoryPeriod enum for mutual fund history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.venv
+/*.egg-info/
+__pycache__/

--- a/pymaya/maya_funds.py
+++ b/pymaya/maya_funds.py
@@ -8,7 +8,6 @@ from pymaya.utils import streamify, Language
 
 
 def _to_date(d: Union[date, datetime, None]) -> Optional[date]:
-    """Normalise a date/datetime/None to a plain date."""
     if d is None:
         return None
     return d.date() if isinstance(d, datetime) else d
@@ -32,7 +31,14 @@ class MayaFunds(MayaBase):
     def get_price_history_chunk(
         self, security_id: str, from_date: date, to_date: date, page: int, lang: Language = Language.ENGLISH
     ) -> List[Dict]:
-        return self._send_request(MayaMutualFundHistoricalRequest(security_id, page=page))
+        return self._send_request(
+            MayaMutualFundHistoricalRequest(
+                security_id,
+                page=page,
+                from_date=_to_date(from_date),
+                to_date=_to_date(to_date),
+            )
+        )
 
     @streamify
     def get_price_history(
@@ -43,18 +49,4 @@ class MayaFunds(MayaBase):
         page: int = 1,
         lang: Language = Language.ENGLISH,
     ) -> List[Dict]:
-        chunk = self.get_price_history_chunk(security_id, from_date, to_date, page, lang)
-        if not chunk:
-            return []
-        from_d = _to_date(from_date)
-        to_d = _to_date(to_date)
-        filtered = []
-        for record in chunk:
-            trade_date = date.fromisoformat(record["tradeDate"][:10])
-            if to_d and trade_date > to_d:
-                continue
-            # Records are in descending order; stop paginating once before from_date
-            if from_d and trade_date < from_d:
-                return filtered
-            filtered.append(record)
-        return filtered
+        return self.get_price_history_chunk(security_id, from_date, to_date, page, lang)

--- a/pymaya/request_classes/maya_mutual_fund_historical_request.py
+++ b/pymaya/request_classes/maya_mutual_fund_historical_request.py
@@ -1,15 +1,33 @@
+from datetime import date
+from typing import Optional
+
 from pymaya.request_classes.maya_base_request import MayaBaseRequest
+from pymaya.utils import FundHistoryPeriod
 
 
 class MayaMutualFundHistoricalRequest(MayaBaseRequest):
     maya_api_base_url = "https://maya.tase.co.il/api/v1/"
     method = "POST"
 
-    def __init__(self, security_id: str, page: int = 1, page_size: int = 20):
+    def __init__(
+        self,
+        security_id: str,
+        page: int = 1,
+        page_size: int = 30,
+        from_date: Optional[date] = None,
+        to_date: Optional[date] = None,
+    ):
         self._security_id = security_id
-        super(MayaMutualFundHistoricalRequest, self).__init__(
-            json={"pageSize": page_size, "pageNumber": page}
-        )
+        body = {"pageSize": page_size, "pageNumber": page}
+        if from_date is not None or to_date is not None:
+            body["period"] = int(FundHistoryPeriod.CUSTOM)
+            if from_date is not None:
+                body["fromDate"] = from_date.isoformat() + "T00:00:00.000Z"
+            if to_date is not None:
+                body["toDate"] = to_date.isoformat() + "T00:00:00.000Z"
+        else:
+            body["period"] = int(FundHistoryPeriod.MONTH)
+        super(MayaMutualFundHistoricalRequest, self).__init__(json=body)
         self.request.headers["referer"] = "https://maya.tase.co.il/"
         self.request.headers["Content-Type"] = "application/json"
         self.request.headers["Accept"] = "application/json"

--- a/pymaya/utils.py
+++ b/pymaya/utils.py
@@ -34,3 +34,12 @@ def get_logger(logger_name) -> Logger:
 class Language(IntEnum):
     HEBREW = 0
     ENGLISH = 1
+
+
+@unique
+class FundHistoryPeriod(IntEnum):
+    MONTH = 0
+    HALF_YEAR = 1
+    YEAR = 2
+    FIVE_YEARS = 3
+    CUSTOM = 4  # requires fromDate / toDate in the request body

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name="pymaya",
-    version="0.5.2",
+    version="0.5.3",
     author="Ben Sterenson",
     author_email="bensterenson@gmail.com",
     description="Python client to interact with maya.tase.co.il",


### PR DESCRIPTION
## Problem

After PR #18 was merged, `get_price_history()` for mutual funds still ignores the requested date range — it always returns only ~20 records regardless of `from_date`/`to_date`.

## Root Cause

The new v1 endpoint was wired up correctly, but `period=0` (1 month) was used unconditionally. The TASE API returns at most ~20 records for `period=0` and does not paginate beyond page 1. The `from_date` / `to_date` arguments were silently ignored.

## Solution

The TASE v1 API supports `period=4` (CUSTOM) mode where `fromDate`/`toDate` are passed in the JSON body. This enables full server-side date filtering with proper pagination (up to 30 records/page, stops on empty response).

A `FundHistoryPeriod` enum is added to make period values self-documenting and avoid magic numbers.

## Changes

| File | Change |
|------|--------|
| `pymaya/utils.py` | Add `FundHistoryPeriod` enum (`MONTH/HALF_YEAR/YEAR/FIVE_YEARS/CUSTOM`) |
| `pymaya/request_classes/maya_mutual_fund_historical_request.py` | Use `CUSTOM` period with `fromDate`/`toDate` when dates are provided; fall back to `MONTH` when no dates given |
| `pymaya/maya_funds.py` | Pass dates through to the request class; remove client-side filtering (server handles it) |

## Verification

| Call | Before | After |
|------|--------|-------|
| `get_price_history(id, from_date=6mo ago)` | ❌ ~20 items, dates ignored | ✅ 120 items |
| `get_price_history(id, from_date=2024-01-01)` | ❌ ~20 items | ✅ 587 items |
| `get_price_history(id)` (no dates) | ✅ ~20 items | ✅ ~20 items (unchanged) |